### PR TITLE
Added link for emit-cheatsheet

### DIFF
--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -63,6 +63,7 @@
         <li><a href="/docs/migrating-from-0-9/">Migrating from 0.9</a></li>
         <li><a href="/docs/using-multiple-nodes/">Using multiple nodes</a></li>
         <li><a href="/docs/logging-and-debugging/">Logging and Debugging</a></li>
+        <li><a href="/docs/emit-cheatsheet/">Emit cheatsheet</a></li>
         <li><a href="/docs/faq/">FAQ</a></li>
       </ul>
     </div>


### PR DESCRIPTION
For some reason emit cheatsheet was missing only on the main docs page.